### PR TITLE
Allows custom-styling of indicator for required inputs

### DIFF
--- a/demo/src/App.css
+++ b/demo/src/App.css
@@ -23,7 +23,6 @@
   margin-left: 20px;
 }
 
-
 .react-stateless-forms-formatted-input {
   position: relative;
   margin-bottom: 16px;
@@ -132,4 +131,8 @@
 .react-stateless-forms-error-box {
   background-color: rgb(235,95,95);
   color: white;
+}
+
+.react-stateless-forms-is-required-input label::after {
+  content: '*';
 }

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -20,6 +20,16 @@ class App extends React.Component {
           <h3>Example: One optional input, one required</h3>
           <p>
             One input is required using the core IsRequiredValidator, the other is left unvalidated.
+            You can custom-style required inputs via CSS, using the class ".react-stateless-forms-is-required-input".
+          </p>
+          <p>
+            For example:
+            <br/>
+            <code>
+              .react-stateless-forms-is-required-input label::after {'{'}
+                content: '*';
+              {'}'}
+            </code>
           </p>
           <RequiredInputsExample />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-stateless-forms",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-stateless-forms",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/dhawt/react-stateless-forms.git"

--- a/src/inputs/validated/index.tsx
+++ b/src/inputs/validated/index.tsx
@@ -1,6 +1,7 @@
 import { withProps } from '../../utilities';
 import { assocPath, isEmpty, omit } from 'ramda';
 import * as React from 'react';
+import * as classNames from 'classnames';
 
 type ValidatedProps = {
   name: string;
@@ -8,6 +9,7 @@ type ValidatedProps = {
   errorMessages?: string;
   onValidate?: (d?: any) => void;
   onChange?: (d?: any) => void;
+  className?: string;
 };
 
 type ValidatedComputedProps = {
@@ -44,8 +46,8 @@ export default <P extends {} = React.SFC<any>>(Child: React.ComponentType<P>): a
         errorMessages: ({ errors, name }: any) =>
           hasErrorMessages({ errors, name }) && toError(errors[name][0]) || null,
       },
-      ({ errorMessages, ...props }: ValidatedProps & ValidatedComputedProps) => (
-        <div className='react-stateless-forms-error-message-container'>
+      ({ errorMessages, className, ...props }: ValidatedProps & ValidatedComputedProps) => (
+        <div className={classNames('react-stateless-forms-error-message-container', className)}>
           <Child {...omit(['onValidate', 'errors'], props) as any} />
           {errorMessages}
         </div>

--- a/src/validated_form/index.tsx
+++ b/src/validated_form/index.tsx
@@ -17,6 +17,8 @@ import * as React from 'react';
 import {
   pipe, all, has, isEmpty, isNil, flatten, map, uniq, values, merge, curry, defaultTo, is, any, keys, pickBy, path
 } from 'ramda';
+import * as classNames from 'classnames';
+
 import ValidationSet from '../validation_set';
 import ErrorBox from '../error_box';
 import { withProps, cloneRecursive } from '../utilities';
@@ -46,18 +48,14 @@ const validatedChildren =
         (formRole && formRole.submit && !isSubmittable({ submitting, fieldErrors, validators }));
       const value = props.name ? path(props.name.split('.'), fieldValues) : undefined;
       const base = !isNil(value) ? { value } : {};
-      let label = '';
-
-      if (props.hasOwnProperty('label')) {
-        label = (validators[key] || []).some(is(IsRequiredValidator)) ? `${props.label}*` : props.label;
-      }
+      const isRequired = (validators[key] || []).some(is(IsRequiredValidator));
 
       return !formRole ? {} : merge(base, {
         key,
         errors: fieldErrors,
         disabled: toDisable,
         onValidate: pipe(merge(fieldValues), onUpdate),
-        label,
+        className: classNames(props.className, { 'react-stateless-forms-is-required-input': isRequired }),
       });
     });
 
@@ -106,7 +104,15 @@ const ValidatedForm = withProps<ValidatedFormProps, any>(
     <div>
       { renderErrors(errors) }
       <form onSubmit={handleSubmit({ submitting, fieldErrors, validators, fieldValues, onSubmit })}>
-        { validatedChildren(children, { submitting, fieldErrors, onUpdate, fieldValues, validators }) }
+        {
+          validatedChildren(children, {
+            submitting,
+            fieldErrors,
+            onUpdate,
+            fieldValues,
+            validators,
+          })
+        }
       </form>
     </div>
 ));


### PR DESCRIPTION
Previously, `validatedForm` automatically appended a "*" to the label value of any input it determined had an instance of `isRequriedValidator`.  This was great, so long as that's how you wanted required inputs to present to the user...

This PR changes the behavior so that instead of messing with the label property of the input, it instead injects a classname on the top-level child via the `Validated` HOC.  This way, anything about a required input can be flexibly styled globally by CSS rules.